### PR TITLE
Add missing typer dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dynamic = ["version", "description"]
-dependencies = ["cryptography", "asn1", "python-dateutil", "pydantic"]
+dependencies = ["cryptography", "asn1", "python-dateutil", "pydantic", "typer"]
 
 [project.optional-dependencies]
 test = ["ruff", "pytest >=2.7.3", "pytest-cov", "mypy"]


### PR DESCRIPTION
Running the CLI without has an error

```
C:\Users\longz\Documents\GitHub\SEP2-Tools>sep2tools
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\longz\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\Scripts\sep2tools.exe\__main__.py", line 4, in <module>
  File "C:\Users\longz\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\sep2tools\cli.py", line 4, in <module>
    import typer
ModuleNotFoundError: No module named 'typer'
```